### PR TITLE
Update Gemfile and Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-gem 'jekyll'
-gem 'jekyll-watch'
-gem 'listen'
-gem 'jekyll-paginate'
+source 'https://rubygems.org'
+
+gem 'jekyll',           '~> 3.1.2'
+gem 'jekyll-watch',     '~> 1.3.1'
+gem 'listen',           '~> 3.0.5'
+gem 'jekyll-paginate',  '~> 1.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,5 @@
 GEM
+  remote: https://rubygems.org/
   specs:
     colorator (0.1)
     ffi (1.9.10)
@@ -33,10 +34,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll
-  jekyll-paginate
-  jekyll-watch
-  listen
+  jekyll (~> 3.1.2)
+  jekyll-paginate (~> 1.1.0)
+  jekyll-watch (~> 1.3.1)
+  listen (~> 3.0.5)
 
 BUNDLED WITH
    1.11.2


### PR DESCRIPTION
Adds a gem source to the Gemfile and sets explicit version dependencies on gems.

I ran into some issues trying to clone and run `bundle install` to install gems. Got:

```
$ bundle install
Your Gemfile has no gem server sources. If you need gems that are not already on your machine, add a line like this to your Gemfile:
source 'https://rubygems.org'
Could not find jekyll-3.1.2 in any of the sources
```

Also sets explicit version dependencies for gems.
